### PR TITLE
- Issue of replicate the logic of populating a ContentValues object f…

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
@@ -314,7 +314,6 @@ public class ContentProviderUtils {
 
     private ContentValues createContentValues(Track track) {
         ContentValues values = new ContentValues();
-        TrackStatistics trackStatistics = track.getTrackStatistics();
 
         if (track.getId() != null) {
             values.put(TracksColumns._ID, track.getId().id());
@@ -325,23 +324,7 @@ public class ContentProviderUtils {
         values.put(TracksColumns.ACTIVITY_TYPE, track.getActivityType() != null ? track.getActivityType().getId() : null);
         values.put(TracksColumns.ACTIVITY_TYPE_LOCALIZED, track.getActivityTypeLocalized());
         values.put(TracksColumns.STARTTIME_OFFSET, track.getZoneOffset().getTotalSeconds());
-        if (trackStatistics.getStartTime() != null) {
-            values.put(TracksColumns.STARTTIME, trackStatistics.getStartTime().toEpochMilli());
-        }
-        if (trackStatistics.getStopTime() != null) {
-            values.put(TracksColumns.STOPTIME, trackStatistics.getStopTime().toEpochMilli());
-        }
-        values.put(TracksColumns.TOTALDISTANCE, trackStatistics.getTotalDistance().toM());
-        values.put(TracksColumns.TOTALTIME, trackStatistics.getTotalTime().toMillis());
-        values.put(TracksColumns.MOVINGTIME, trackStatistics.getMovingTime().toMillis());
-        values.put(TracksColumns.AVGSPEED, trackStatistics.getAverageSpeed().toMPS());
-        values.put(TracksColumns.AVGMOVINGSPEED, trackStatistics.getAverageMovingSpeed().toMPS());
-        values.put(TracksColumns.MAXSPEED, trackStatistics.getMaxSpeed().toMPS());
-        values.put(TracksColumns.MIN_ALTITUDE, trackStatistics.getMinAltitude());
-        values.put(TracksColumns.MAX_ALTITUDE, trackStatistics.getMaxAltitude());
-        values.put(TracksColumns.ALTITUDE_GAIN, trackStatistics.getTotalAltitudeGain());
-        values.put(TracksColumns.ALTITUDE_LOSS, trackStatistics.getTotalAltitudeLoss());
-
+        values.putAll(createContentValues(track.getTrackStatistics()));
         return values;
     }
 


### PR DESCRIPTION
# Thanks for your contribution.


**Describe the pull request**
The code snippet provided appears to replicate the logic of populating a ContentValues object with track statistics, such as start time, stop time, total distance, total time, altitude, and speeds, using values from a trackStatistics object. This logic seems to be a straightforward copy-paste of similar patterns for handling different fields of trackStatistics without any modification or abstraction, resulting in a "clone" of the structure so I fixed by putting all the values with putAll and existing createContentValues function.


**Code before refactoring**
<img width="1147" alt="Screenshot 2024-11-06 at 6 19 42 pm" src="https://github.com/user-attachments/assets/46fabf6a-ce68-4751-ab90-a92208144c24">



**Code after refactoring**
<img width="1147" alt="Screenshot 2024-11-06 at 6 46 35 pm" src="https://github.com/user-attachments/assets/9fa38a6b-f251-4a6b-b355-eb987ac2f929">

**Link to the the issue**
Upstream issue : [25](https://github.com/rilling/opentracksFall2024/issues/25)
Issue #5 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
