### PR TITLE
Refactored TrackStatisticsUpdaterTest.java for addTrackPoint_idle_withoutDistance and addTrackPoint_idle_withDistance to remove software clone

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -209,18 +209,12 @@ public class TrackStatisticsUpdaterTest {
         assertEquals(Speed.of(2f), subject.getTrackStatistics().getMaxSpeed());
     }
 
-    @Test
-    public void addTrackPoint_idle_withoutDistance() {
-        TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
-
-        // when
+    // Helper method to add common track points
+    private void addCommonTrackPoints(TrackStatisticsUpdater subject) {
         subject.addTrackPoints(List.of(
                 new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochSecond(0)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(1))
-                        .setSpeed(Speed.of(2f)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(2))
-                        .setSpeed(Speed.of(2f)),
-
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(1)),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(2)),
                 new TrackPoint(TrackPoint.Type.IDLE, Instant.ofEpochSecond(30)),
                 new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochSecond(40))
                         .setHeartRate(50),
@@ -228,8 +222,23 @@ public class TrackStatisticsUpdaterTest {
                         .setHeartRate(50),
                 new TrackPoint(0, 1, Altitude.WGS84.of(0), Instant.ofEpochSecond(50)),
                 new TrackPoint(0, 2, Altitude.WGS84.of(0), Instant.ofEpochSecond(55)),
-
                 new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochSecond(60))
+        ));
+    }
+
+    @Test
+    public void addTrackPoint_idle_withoutDistance() {
+        TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
+
+        // Add common track points without setting sensor distance
+        addCommonTrackPoints(subject);
+
+        // when
+        subject.addTrackPoints(List.of(
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(1))
+                        .setSpeed(Speed.of(2f)),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(2))
+                        .setSpeed(Speed.of(2f))
         ));
 
         // then
@@ -240,9 +249,11 @@ public class TrackStatisticsUpdaterTest {
     public void addTrackPoint_idle_withDistance() {
         TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
 
+        // Add common track points with sensor distance
+        addCommonTrackPoints(subject);
+
         // when
         subject.addTrackPoints(List.of(
-                new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochSecond(0)),
                 new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(1))
                         .setSensorDistance(Distance.of(10)),
                 new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(2))
@@ -250,16 +261,10 @@ public class TrackStatisticsUpdaterTest {
 
                 new TrackPoint(TrackPoint.Type.IDLE, Instant.ofEpochSecond(30))
                         .setSensorDistance(Distance.ofKilometer(1)),
-                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochSecond(40))
-                        .setHeartRate(50),
-                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochSecond(45))
-                        .setHeartRate(50),
                 new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(50))
                         .setSensorDistance(Distance.of(10)),
                 new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(55))
-                        .setSensorDistance(Distance.of(10)),
-
-                new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochSecond(60))
+                        .setSensorDistance(Distance.of(10))
         ));
 
         // then


### PR DESCRIPTION

# Thanks for your contribution.



**Describe the pull request**

The code snippet provided appears to replicate the logic of creating TrackPoint objects in both the addTrackPoint_idle_withoutDistance and addTrackPoint_idle_withDistance methods. Both methods follow the same structure for initializing TrackPoint objects, with only minor differences related to distance. This repetition of logic leads to code duplication, as similar patterns for creating and populating TrackPoint objects are copy-pasted without any abstraction or modification., which I removed by introducing a helper method addCommonTrackPoints for common logic.

**Code before refactoring**

<img width="792" alt="Screenshot 2024-11-10 at 8 01 30 PM" src="https://github.com/user-attachments/assets/241fc1d6-3dab-4b6c-977c-726713eb9594">
<img width="1010" alt="Screenshot 2024-11-10 at 8 01 38 PM" src="https://github.com/user-attachments/assets/77b568a3-d28a-41d6-a303-a33424e4d1ea">

**Code after refactoring**

<img width="895" alt="Screenshot 2024-11-10 at 10 08 05 PM" src="https://github.com/user-attachments/assets/1f0a6875-973a-4649-bf6f-30d11d88d61d">
<img width="876" alt="Screenshot 2024-11-10 at 10 08 16 PM" src="https://github.com/user-attachments/assets/cfbcab57-a6f0-44e1-9f9f-0a5d91037f7b">

**Link to the the issue** [#Issue](https://github.com/rilling/opentracksFall2024/issues/35)

