### PR TITLE
Refactored MarkerUtils.java to remove software clone

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerUtils.java
@@ -37,6 +37,20 @@ public class MarkerUtils {
         return ContextCompat.getDrawable(context, ICON_ID);
     }
 
+
+    /**
+     * Creates a unique file for storing photos in the track's folder.
+     *
+     * @param context the context
+     * @param trackId the track id
+     * @return the unique file
+     */
+    private static File createUniquePhotoFile(Context context, Track.Id trackId) {
+        File dir = FileUtils.getPhotoDir(context, trackId);
+        String fileName = SimpleDateFormat.getDateTimeInstance().format(new Date());
+        return new File(dir, FileUtils.buildUniqueFileName(dir, fileName, JPEG_EXTENSION));
+    }
+
     /**
      * Sends a take picture request to the camera app.
      * The picture is then stored in the track's folder.
@@ -45,11 +59,7 @@ public class MarkerUtils {
      * @param trackId the track id
      */
     static Pair<Intent, Uri> createTakePictureIntent(Context context, Track.Id trackId) {
-        File dir = FileUtils.getPhotoDir(context, trackId);
-
-        String fileName = SimpleDateFormat.getDateTimeInstance().format(new Date());
-        File file = new File(dir, FileUtils.buildUniqueFileName(dir, fileName, JPEG_EXTENSION));
-
+        File file = createUniquePhotoFile(context, trackId);
         Uri photoUri = FileProvider.getUriForFile(context, FileUtils.FILEPROVIDER, file);
         Log.d(TAG, "Taking photo to URI: " + photoUri);
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE)
@@ -59,12 +69,7 @@ public class MarkerUtils {
 
     @VisibleForTesting(otherwise = 3)
     public static String getImageUrl(Context context, Track.Id trackId) {
-        File dir = FileUtils.getPhotoDir(context, trackId);
-
-        String fileName = SimpleDateFormat.getDateTimeInstance().format(new Date());
-        File file = new File(dir, FileUtils.buildUniqueFileName(dir, fileName, JPEG_EXTENSION));
-
-        return file.getAbsolutePath();
+        return createUniquePhotoFile(context, trackId).getAbsolutePath();
     }
 
     /**


### PR DESCRIPTION
# Thanks for your contribution.

**Describe the pull request**

The  code snippet appears to replicate the logic of creating and managing unique file paths and URIs for storing photos taken within the context of a specific track. This involves repeatedly generating a directory path for the track, constructing a timestamp-based filename to ensure uniqueness, and setting up the corresponding file path and URI. These steps are directly mirrored across multiple methods, each duplicating the same sequence of operations without abstraction or centralization, resulting in a "clone" of the process, which I resolved by creating helper method createUniquePhotoFile.



**Code before refactoring**

<img width="1251" alt="Screenshot 2024-11-11 at 12 41 27 PM" src="https://github.com/user-attachments/assets/f15e4eec-5bcd-4edc-8dad-1df96dc1aaf4">


**Code after refactoring**

<img width="1221" alt="Screenshot 2024-11-11 at 12 46 30 PM" src="https://github.com/user-attachments/assets/b3dd2a79-3752-4c29-a00e-63b43dadda72">


**Link to the the Issue** [#Issue](https://github.com/rilling/opentracksFall2024/issues/39)
