### PR TITLE
- Fixed issue of Path Traversal issue in KmzTrackImporter.java

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -231,13 +231,23 @@ public class KmzTrackImporter {
      * @param fileName       the file name
      */
     private void readAndSaveImageFile(ZipInputStream zipInputStream, Track.Id trackId, String fileName) throws IOException {
-        if (trackId == null || "".equals(fileName)) {
+        if (trackId == null || fileName.isEmpty()) {
             return;
         }
 
-        File dir = FileUtils.getPhotoDir(context, trackId);
-        File file = new File(dir, fileName);
+        // Sanitize the file name to prevent directory traversal
+        String sanitizedFileName = sanitizeFileName(fileName);
 
+        // Get the photo directory for this track
+        File dir = FileUtils.getPhotoDir(context, trackId);
+        File file = new File(dir, sanitizedFileName);
+
+        // Ensure the file is within the intended directory (canonical path check)
+        if (!file.getCanonicalPath().startsWith(dir.getCanonicalPath())) {
+            throw new IOException("Attempt to write outside the allowed directory.");
+        }
+
+        // Proceed with file extraction and saving
         try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 zipInputStream.transferTo(fileOutputStream);
@@ -249,5 +259,25 @@ public class KmzTrackImporter {
                 }
             }
         }
+    }
+
+    /**
+     * Sanitizes fileName to avoid path traversal and ensures it's safe to use in the file system.
+     *
+     * @param fileName : Name of the file
+     * @return : Sanitized name
+     */
+    public static String sanitizeFileName(String fileName) {
+        if (fileName == null) return "";
+
+        // Normalize filename: Remove any traversal sequences and unsafe characters
+        String sanitizedFileName = fileName.replace("../", "")  // Remove any attempt to go up directories
+                .replace("..\\", "") // Windows style
+                .replace(File.separatorChar, '-'); // Normalize separators
+
+        // Optionally, check that the sanitized filename does not include any other risky characters:
+        sanitizedFileName = sanitizedFileName.replaceAll("[<>:\"/\\|?*]", "");  // Remove characters that are unsafe for filenames
+
+        return sanitizedFileName;
     }
 }


### PR DESCRIPTION
# Thanks for your contribution.

**Describe the pull request**
Unsanitized input from a zip file flows into java.io.FileOutputStream, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to write to arbitrary files.

CVE
CWE-23: Relative Path Traversal

**Fix provided**
Used a malicious archive that holds path traversal filenames. When each filename in the archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.

**Code before refactoring**
<img width="1147" alt="Screenshot 2024-11-24 at 3 02 32 pm" src="https://github.com/user-attachments/assets/7f35166d-3f9d-4734-ab95-95f348e73790">


**Code after refactoring**
![Screenshot 2024-11-24 at 5 54 16 pm](https://github.com/user-attachments/assets/505d5195-cdf7-4e24-9044-7318515abc92)

**Link to the the issue**
Upstream issue : Issue [56](https://github.com/rilling/opentracksFall2024/issues/56)

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
