### PR TITLE
Fixing Android Intent Forwarding issue in TrackStoppedActivity.java - Closes #61

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackStoppedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackStoppedActivity.java
@@ -38,7 +38,15 @@ public class TrackStoppedActivity extends AbstractTrackDeleteActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        trackId = getIntent().getParcelableExtra(EXTRA_TRACK_ID);
+        Intent intent = getIntent();
+        if (intent == null || !intent.hasExtra(EXTRA_TRACK_ID)) {
+            Log.e(TAG, "Invalid or missing EXTRA_TRACK_ID.");
+            finish();
+            return;
+        }
+
+        // Validate the track ID
+        trackId = intent.getParcelableExtra(EXTRA_TRACK_ID);
         if (trackId == null) {
             Log.e(TAG, "TrackStoppedActivity needs EXTRA_TRACK_ID.");
             finish();


### PR DESCRIPTION
**Describe the pull request**
This pull request fixes a vulnerability in TrackStoppedActivity.java, where unsanitized input from Activity.getIntent() flows into startActivity TrackStoppedActivity's resumeTrackAndFinish() function, where it is used to start an Activity. If the Android component where the Intent was acquired is exported and the Intent originates from a third-party application, this could provide the third-party application access to unauthorised functionality or data within the target application.
The change is made to make sure trackID and intent is validated to avoid this vulnerability.

**CVE**
CWE-940: Improper Verification of Source of a Communication Channel

**Fix provided:**
The fix ensures that the incoming intent is validated for the presence of `EXTRA_TRACK_ID` before proceeding with the activity. If the intent is invalid or missing the required extra, an error is logged, and the activity is finished immediately to prevent further issues.

**Code before refactoring:**
![image](https://github.com/user-attachments/assets/e583c8e5-4645-4eff-8dca-06ce269f0153)

**Code after refactoring:**
![image](https://github.com/user-attachments/assets/e592f401-ef83-42e6-bf06-aafbd4a3b99b)

**Link to the the issue**
Upstream issue: Fixes #61

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
